### PR TITLE
[release-2.7] Set cgo flag on PROMU to build dynamically linked binary

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -5,7 +5,7 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
 WORKDIR /workspace
 COPY . .
 
-RUN go install github.com/prometheus/promu@v0.12.0 && promu build --prefix ./
+RUN go install github.com/prometheus/promu@v0.12.0 && promu build --cgo --prefix ./
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,11 @@ docker: npm_licenses common-docker
 .PHONY: build
 build: assets common-build
 
+# NOTICE: must --cgo flag to build dynamically linked binary for FIPS compliance
 .PHONY: bench_tsdb
 bench_tsdb: $(PROMU)
 	@echo ">> building promtool"
-	@GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) promtool
+	@GO111MODULE=$(GO111MODULE) $(PROMU) build --cgo --prefix $(PREFIX) promtool
 	@echo ">> running benchmark, writing result to $(TSDB_BENCHMARK_OUTPUT_DIR)"
 	@$(PROMTOOL) tsdb bench write --metrics=$(TSDB_BENCHMARK_NUM_METRICS) --out=$(TSDB_BENCHMARK_OUTPUT_DIR) $(TSDB_BENCHMARK_DATASET)
 	@$(GO) tool pprof -svg $(PROMTOOL) $(TSDB_BENCHMARK_OUTPUT_DIR)/cpu.prof > $(TSDB_BENCHMARK_OUTPUT_DIR)/cpuprof.svg

--- a/Makefile.common
+++ b/Makefile.common
@@ -221,10 +221,11 @@ endif
 endif
 endif
 
+# NOTICE: must --cgo flag to build dynamically linked binary for FIPS compliance
 .PHONY: common-build
 common-build: promu
 	@echo ">> building binaries"
-	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --cgo --prefix $(PREFIX) $(PROMU_BINARIES)
 
 .PHONY: common-tarball
 common-tarball: promu


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
Adding `--cgo` flag to ensure builds are dynamically linked.