### PR TITLE
use go 1.20 builder image

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
update Dockerfile.prow builder image to go 1.20

This is a prerequisite step before CI files can be updated to go 1.20