### PR TITLE
[release-2.10] Update promu version to 0.17.0

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -6,7 +6,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS bui
 WORKDIR /workspace
 COPY . .
 
-RUN go install -mod=mod github.com/prometheus/promu@v0.15.0 && go mod vendor && /go/bin/promu build -v --cgo --prefix ./
+RUN go install -mod=mod github.com/prometheus/promu@v0.17.0 && go mod vendor && /go/bin/promu build -v --cgo --prefix ./
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -5,7 +5,7 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
 WORKDIR /workspace
 COPY . .
 
-RUN go install github.com/prometheus/promu@v0.15.0 && promu build -v --cgo --prefix ./
+RUN go install github.com/prometheus/promu@v0.17.0 && promu build -v --cgo --prefix ./
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 


### PR DESCRIPTION
Fixes CVE-2024-45337/45338

Promu 0.15.0 uses older version of  golang.org/x/net 
Promu 0.17.0 no longer has dependency on golang.org/x/net 
