### PR TITLE
[release-2.9] update promu version to 0.17.0

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -5,7 +5,7 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
 WORKDIR /workspace
 COPY . .
 
-RUN go install github.com/prometheus/promu@v0.15.0 && promu build -v --cgo --prefix ./
+RUN go install github.com/prometheus/promu@v0.17.0 && promu build -v --cgo --prefix ./
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-v778-237x-gjrc/45338

Promu 0.15.0 uses older version of golang.org/x/net
Promu 0.17.0 no longer has dependency on golang.org/x/net