### PR TITLE
Set UID instead of username

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -27,7 +27,7 @@ RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles
 RUN mkdir -p /prometheus && \
     chown -R nobody:nobody etc/prometheus /prometheus
 
-USER       nobody
+USER       1001
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -24,7 +24,7 @@ RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles
 RUN mkdir -p /prometheus && \
     chown -R nobody:nobody etc/prometheus /prometheus
 
-USER       nobody
+USER       1001
 EXPOSE     9090
 VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus


### PR DESCRIPTION
Fixes the following which occurs in MCOA on non-ocp clusters.
```
CreateContainerConfigError: “container has runAsNonRoot and image has non-numeric user (nobody),  cannot verify user is non-root”
```