### PR TITLE
Security: Fix CVE-2026-32285 (github.com/buger/jsonparser)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
 	github.com/go-openapi/swag/conv v0.25.4 // indirect
 	github.com/go-openapi/swag/fileutils v0.25.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/buger/jsonparser v1.2.0 h1:4EFcvK1kD4jyj6YqNK6skK6w+y7FHHBR+XBCtxwu/6g=
+github.com/buger/jsonparser v1.2.0/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
<!-- cve-fixer-workflow -->

## CVE Details

| Field | Value |
|-------|-------|
| **CVE ID** | CVE-2026-32285 |
| **GHSA** | GHSA-6g7g-w4f8-9c9x |
| **Severity** | HIGH |
| **Affected Package** | github.com/buger/jsonparser |
| **Vulnerable Versions** | <= 1.1.1 |
| **Fixed Version** | v1.2.0 |
| **Jira Issue** | ACM-33929 |

## Fix Summary

Updated the indirect dependency `github.com/buger/jsonparser` from **v1.1.1** to **v1.2.0** to remediate CVE-2026-32285, a HIGH severity vulnerability in the JSON parser library.

### Changes Made
- `go.mod`: Updated `github.com/buger/jsonparser` version constraint from v1.1.1 to v1.2.0
- `go.sum`: Updated checksums for the new version
- Ran `go mod tidy` to ensure dependency graph consistency

## Risk Assessment

**Risk Level: Low**

- This is an **indirect dependency** update (no direct import changes)
- The update is a minor version bump (v1.1.1 -> v1.2.0) within the same major version
- `go mod tidy` completed successfully with no dependency conflicts
- No breaking API changes expected for indirect consumers

## Test Results

> Tests were not executed as part of this PR. Manual testing or CI pipeline validation is recommended before merging.

## Verification Steps

- [ ] CI pipeline passes successfully
- [ ] Verify `github.com/buger/jsonparser v1.2.0` appears in `go.mod`
- [ ] Run `govulncheck ./...` to confirm CVE-2026-32285 is resolved
- [ ] Run project test suite to verify no regressions
- [ ] Validate that the application builds and starts correctly

## Breaking Changes

None expected. This is a patch/minor version update of an indirect dependency within the same major version (v1.x.x).

Resolves: ACM-33929