### PR TITLE
First pass of enabling prometheus testing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,4 +256,3 @@ jobs:
     permissions:
       contents: read
       security-events: write
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: read
 
-permissions:
-  contents: read
-
 jobs:
   test_go:
     name: Go tests
@@ -260,88 +257,3 @@ jobs:
       contents: read
       security-events: write
 
-  publish_main:
-    name: Publish main branch artifacts
-    runs-on: ubuntu-latest
-    needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
-    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-      - uses: prometheus/promci@fc721ff8497a70a93a881cd552b71af7fb3a9d53 # v0.5.4
-      - uses: ./.github/promci/actions/publish_main
-        with:
-          docker_hub_login: ${{ secrets.docker_hub_login }}
-          docker_hub_password: ${{ secrets.docker_hub_password }}
-          quay_io_login: ${{ secrets.quay_io_login }}
-          quay_io_password: ${{ secrets.quay_io_password }}
-  publish_release:
-    name: Publish release artefacts
-    runs-on: ubuntu-latest
-    needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
-      ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-      - uses: prometheus/promci@fc721ff8497a70a93a881cd552b71af7fb3a9d53 # v0.5.4
-      - uses: ./.github/promci/actions/publish_release
-        with:
-          docker_hub_login: ${{ secrets.docker_hub_login }}
-          docker_hub_password: ${{ secrets.docker_hub_password }}
-          quay_io_login: ${{ secrets.quay_io_login }}
-          quay_io_password: ${{ secrets.quay_io_password }}
-          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}
-  publish_ui_release:
-    name: Publish UI on npm Registry
-    runs-on: ubuntu-latest
-    needs: [test_ui, codeql]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-      - uses: prometheus/promci@fc721ff8497a70a93a881cd552b71af7fb3a9d53 # v0.5.4
-      - name: Install nodejs
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        with:
-          node-version-file: "web/ui/.nvmrc"
-          registry-url: "https://registry.npmjs.org"
-      - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Check libraries version
-        if: |
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
-          ||
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
-        run: ./scripts/ui_release.sh --check-package "$(./scripts/get_module_version.sh ${GH_REF_NAME})"
-        env:
-          GH_REF_NAME: ${{ github.ref_name }}
-      - name: build
-        run: make assets
-      - name: Copy files before publishing libs
-        run: ./scripts/ui_release.sh --copy
-      - name: Publish dry-run libraries
-        if: |
-          !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
-          &&
-          !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
-        run: ./scripts/ui_release.sh --publish dry-run
-      - name: Publish libraries
-        if: |
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
-          ||
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
-        run: ./scripts/ui_release.sh --publish
-        env:
-          # The setup-node action writes an .npmrc file with this env variable
-          # as the placeholder for the auth token
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@
 extends: default
 ignore: |
   **/node_modules
+  .tekton/
   web/api/v1/testdata/openapi_*_golden.yaml
 
 rules:

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -860,7 +860,7 @@ scrape_configs:
 				if err != nil {
 					return false
 				}
-				if compactions < 3 {
+				if compactions < 99999 {
 					return false
 				}
 

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -860,7 +860,7 @@ scrape_configs:
 				if err != nil {
 					return false
 				}
-				if compactions < 99999 {
+				if compactions < 3 {
 					return false
 				}
 


### PR DESCRIPTION
MR of adding e2e tests for prometheus (fuzzing currently skipped by default) into our workflow. Some slight edits needed to remove unnecessary steps for our use case and to skip tekton files. Resolves https://redhat.atlassian.net/browse/ACM-34924